### PR TITLE
Restored previously deprecated API in order to allow for a longer transition period

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>info.novatec.testit</groupId>
 	<artifactId>webtester</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>pom</packaging>
 
 	<name>testIT | WebTester</name>

--- a/webtester-core/pom.xml
+++ b/webtester-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-core</artifactId>

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/eventsystem/EventSystem.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/eventsystem/EventSystem.java
@@ -56,6 +56,19 @@ public final class EventSystem {
     }
 
     /**
+     * Unregisters an {@link EventListener event listener}. It will no longer be
+     * informed of any {@link Event events} that are reported by the framework.
+     *
+     * @param listener the {@link EventListener event listener} to unregister.
+     * @since 0.9.0
+     * @deprecated use {@link #deregisterListener(EventListener)} instead - will be removed with release of v1.1.0
+     */
+    @Deprecated
+    public static void unregisterListener(EventListener listener) {
+        deregisterListener(listener);
+    }
+
+    /**
      * Removes all {@link EventListener event listeners} from the registry.
      *
      * @since 0.9.0

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/utils/Waits.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/utils/Waits.java
@@ -217,6 +217,105 @@ public final class Waits {
     }
 
     /**
+     * Wait until the given {@linkplain PageObject page object} is present in
+     * the DOM. Uses the configured default timeout.
+     *
+     * @param pageObject the page object
+     * @throws TimeoutException if element never became present
+     * @since 0.9.6
+     * @deprecated use
+     * <code>waitUntil(pageObject, Conditions.is(Conditions.present()));</code>
+     * instead. Will be removed with 1.1.0!
+     */
+    @Deprecated
+    public static void waitUntilPresent(PageObject pageObject) {
+        waitUntilPresent(pageObject, getWaitTimeout(pageObject));
+    }
+
+    /**
+     * Wait until the given {@linkplain PageObject page object} is present in
+     * the DOM.
+     *
+     * @param pageObject the page object
+     * @param timeout the maximum time to wait in seconds
+     * @throws TimeoutException if element never became present
+     * @since 0.9.6
+     * @deprecated use
+     * <code>waitSecondsUntil(timeout, pageObject, Conditions.is(Conditions.present()));</code>
+     * instead. Will be removed with 1.1.0!
+     */
+    @Deprecated
+    public static void waitUntilPresent(PageObject pageObject, final int timeout) {
+        waitSecondsUntil(timeout, pageObject, Conditions.present());
+    }
+
+    /**
+     * Wait until the given {@linkplain PageObject page object} is visible on
+     * the page. Uses the configured default timeout.
+     *
+     * @param pageObject the page object
+     * @throws TimeoutException if element never became visible
+     * @since 0.9.6
+     * @deprecated use
+     * <code>waitUntil(pageObject, Conditions.is(Conditions.visible()));</code>
+     * instead. Will be removed with 1.1.0!
+     */
+    @Deprecated
+    public static void waitUntilVisible(PageObject pageObject) {
+        waitUntilVisible(pageObject, getWaitTimeout(pageObject));
+    }
+
+    /**
+     * Wait until the given {@linkplain PageObject page object} is visible on
+     * the page.
+     *
+     * @param pageObject the page object
+     * @param timeout the maximum time to wait in seconds
+     * @throws TimeoutException if element never became visible
+     * @since 0.9.6
+     * @deprecated use
+     * <code>waitSecondsUntil(timeout, pageObject, Conditions.is(Conditions.visible()));</code>
+     * instead. Will be removed with 1.1.0!
+     */
+    @Deprecated
+    public static void waitUntilVisible(PageObject pageObject, final int timeout) {
+        waitSecondsUntil(timeout, pageObject, Conditions.visible());
+    }
+
+    /**
+     * Wait until the given {@linkplain PageObject page object} is not visible
+     * on the page. Uses the configured default timeout.
+     *
+     * @param pageObject the page object
+     * @throws TimeoutException if element never became invisible
+     * @since 0.9.6
+     * @deprecated use
+     * <code>waitUntil(pageObject, Conditions.is(Conditions.invisible()));</code>
+     * instead. Will be removed with 1.1.0!
+     */
+    @Deprecated
+    public static void waitUntilInvisible(PageObject pageObject) {
+        waitUntilInvisible(pageObject, getWaitTimeout(pageObject));
+    }
+
+    /**
+     * Wait until the given {@linkplain PageObject page object} is not visible
+     * on the page.
+     *
+     * @param pageObject the page object
+     * @param timeout the maximum time to wait in seconds
+     * @throws TimeoutException if element never became invisible
+     * @since 0.9.6
+     * @deprecated use
+     * <code>waitSecondsUntil(timeout, pageObject, Conditions.is(Conditions.invisible()));</code>
+     * instead. Will be removed with 1.1.0!
+     */
+    @Deprecated
+    public static void waitUntilInvisible(PageObject pageObject, final int timeout) {
+        waitSecondsUntil(timeout, pageObject, Conditions.invisible());
+    }
+
+    /**
      * Waits until the given {@link Predicate condition} is met by the provided
      * {@link PageObject page object}. The page object's browser's configuration
      * is used to retrieve the timeout (in seconds) and check interval to use.

--- a/webtester-support-assertj/pom.xml
+++ b/webtester-support-assertj/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-support-assertj</artifactId>

--- a/webtester-support-chrome/pom.xml
+++ b/webtester-support-chrome/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-support-chrome</artifactId>

--- a/webtester-support-firefox/pom.xml
+++ b/webtester-support-firefox/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-support-firefox</artifactId>

--- a/webtester-support-hamcrest/pom.xml
+++ b/webtester-support-hamcrest/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-support-hamcrest</artifactId>

--- a/webtester-support-ie/pom.xml
+++ b/webtester-support-ie/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-support-ie</artifactId>

--- a/webtester-support-junit/pom.xml
+++ b/webtester-support-junit/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-support-junit</artifactId>

--- a/webtester-support-spring4/pom.xml
+++ b/webtester-support-spring4/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>webtester</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>webtester-support-spring4</artifactId>


### PR DESCRIPTION
Projects using pre-release versions of WebTester need a longer transition time. So some of the deprecated API was restored.