### PR TITLE
Some Optimizations and Java 7 Upgrades

### DIFF
--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/BrowserCallbackWithReturnValue.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/BrowserCallbackWithReturnValue.java
@@ -7,9 +7,9 @@ import info.novatec.testit.webtester.api.browser.Browser;
  * A {@link CallbackWithReturnValue callback with return value} specialized for
  * {@link Browser browser} input type.
  *
- * @param <B> the return type of the callback
+ * @param <R> the return type of the callback
  * @since 0.9.0
  */
-public interface BrowserCallbackWithReturnValue<B> extends CallbackWithReturnValue<Browser, B> {
+public interface BrowserCallbackWithReturnValue<R> extends CallbackWithReturnValue<Browser, R> {
     // nothing special - just simplifying the API
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/Callback.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/Callback.java
@@ -4,10 +4,10 @@ package info.novatec.testit.webtester.api.callbacks;
  * A functional callback interface with one parameter of type A and no return
  * value.
  *
- * @param <A> the input type of the callback method
+ * @param <P> the parameter type of the callback method
  * @since 0.9.0
  */
-public interface Callback<A> {
+public interface Callback<P> {
 
     /**
      * This method is called by an action template and contains the logic of the
@@ -16,6 +16,6 @@ public interface Callback<A> {
      * @param arg the input parameter
      * @since 0.9.0
      */
-    void execute(A arg);
+    void execute(P arg);
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/CallbackWithReturnValue.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/CallbackWithReturnValue.java
@@ -4,11 +4,11 @@ package info.novatec.testit.webtester.api.callbacks;
  * A functional callback interface with one parameter of type A and a return
  * value of type B.
  *
- * @param <A> the input type of the callback method
- * @param <B> the return type of the callback method
+ * @param <P> the parameter type of the callback method
+ * @param <R> the return type of the callback method
  * @since 0.9.0
  */
-public interface CallbackWithReturnValue<A, B> {
+public interface CallbackWithReturnValue<P, R> {
 
     /**
      * This method is called by an action template and contains the logic of the
@@ -18,6 +18,6 @@ public interface CallbackWithReturnValue<A, B> {
      * @return the return value
      * @since 0.9.0
      */
-    B execute(A arg);
+    R execute(P arg);
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/PageObjectCallbackWithReturnValue.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/callbacks/PageObjectCallbackWithReturnValue.java
@@ -7,9 +7,9 @@ import info.novatec.testit.webtester.pageobjects.PageObject;
  * A {@link CallbackWithReturnValue callback with return value} specialized for
  * {@link PageObject page object} input type.
  *
- * @param <B> the return type of the callback
+ * @param <P> the return type of the callback
  * @since 0.9.0
  */
-public interface PageObjectCallbackWithReturnValue<B> extends CallbackWithReturnValue<PageObject, B> {
+public interface PageObjectCallbackWithReturnValue<P> extends CallbackWithReturnValue<PageObject, P> {
     // nothing special - just simplifying the API
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/config/Configuration.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/config/Configuration.java
@@ -23,7 +23,7 @@ import info.novatec.testit.webtester.utils.Waits;
  * Since they provide for a comfortable way to use specific
  * {@link ConfigurationAdapter adapters} and {@link ConfigurationExporter
  * exporters} to adapt (change configuration based on different sources) and
- * export the confiuguration's properties and values.
+ * export the configuration's properties and values.
  * <p>
  * Besides a number of 'named' properties with their own setter- and
  * getter-methods custom properties can be set and read as well.

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/ReflectionUtils.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/ReflectionUtils.java
@@ -2,7 +2,6 @@ package info.novatec.testit.webtester.internal;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Deque;
@@ -24,7 +23,7 @@ public final class ReflectionUtils {
 
     @Internal
     public static <T> T forceCreateInstance(Class<T> clazz, Object... constructionParameters)
-        throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+        throws ReflectiveOperationException {
 
         Class<?>[] parameterClasses = getParameterClasses(constructionParameters);
         Constructor<T> classConstructor = clazz.getDeclaredConstructor(parameterClasses);
@@ -35,7 +34,7 @@ public final class ReflectionUtils {
 
     @Internal
     public static <T> T forceCreateInstance(Constructor<T> classConstructor, Object... constructionParameters)
-        throws InstantiationException, IllegalAccessException, InvocationTargetException {
+        throws ReflectiveOperationException {
 
         classConstructor.setAccessible(true);
         return classConstructor.newInstance(constructionParameters);
@@ -56,21 +55,20 @@ public final class ReflectionUtils {
     /* getting fields */
 
     @Internal
-    public static Object forceGetFieldValue(Class<?> clazz, String fieldName)
-        throws NoSuchFieldException, IllegalAccessException {
+    public static Object forceGetFieldValue(Class<?> clazz, String fieldName) throws ReflectiveOperationException {
         return forceGetFieldValue(clazz, null, fieldName);
     }
 
     @Internal
     public static Object forceGetFieldValue(Class<?> clazz, Object objectInstance, String fieldName)
-        throws NoSuchFieldException, IllegalAccessException {
+        throws ReflectiveOperationException {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         return field.get(objectInstance);
     }
 
     @Internal
-    public static Object forceGetFieldValue(Field field, Object objectInstance) throws IllegalAccessException {
+    public static Object forceGetFieldValue(Field field, Object objectInstance) throws ReflectiveOperationException {
         field.setAccessible(true);
         return field.get(objectInstance);
     }
@@ -79,20 +77,21 @@ public final class ReflectionUtils {
 
     @Internal
     public static void forceSetField(Class<?> clazz, String fieldName, Object fieldValue)
-        throws NoSuchFieldException, IllegalAccessException {
+        throws ReflectiveOperationException {
         Field field = clazz.getDeclaredField(fieldName);
         forceSetField(field, null, fieldValue);
     }
 
     @Internal
     public static void forceSetField(String fieldName, Object objectInstance, Object fieldValue)
-        throws NoSuchFieldException, IllegalAccessException {
+        throws ReflectiveOperationException {
         Field field = objectInstance.getClass().getDeclaredField(fieldName);
         forceSetField(field, objectInstance, fieldValue);
     }
 
     @Internal
-    public static void forceSetField(Field field, Object objectInstance, Object fieldValue) throws IllegalAccessException {
+    public static void forceSetField(Field field, Object objectInstance, Object fieldValue)
+        throws ReflectiveOperationException {
         field.setAccessible(true);
         field.set(objectInstance, fieldValue);
     }
@@ -101,7 +100,7 @@ public final class ReflectionUtils {
 
     @Internal
     public static Object forceInvokeMethod(Method method, Object objectInstance, Object... methodParameters)
-        throws IllegalAccessException, InvocationTargetException {
+        throws ReflectiveOperationException {
         method.setAccessible(true);
         return method.invoke(objectInstance, methodParameters);
     }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/annotations/SetViaInjection.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/annotations/SetViaInjection.java
@@ -6,14 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
- * Describes a possible optimization using Java 7 features. These optimizations
- * should be implemented as soon as WebTester support for Java 6 ends.
+ * Marks a field as 'injected'. This annotation is not used pragmatically.
+ * It exists just to clarify code pieces where some 'magic' happens.
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE)
-@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.METHOD })
-public @interface Java7FeaturePossibility {
-    String value();
+@Target(ElementType.FIELD)
+public @interface SetViaInjection {
+    // NOPROPS
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/pageobjects/ActionTemplate.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/pageobjects/ActionTemplate.java
@@ -1,0 +1,156 @@
+package info.novatec.testit.webtester.internal.pageobjects;
+
+import static info.novatec.testit.webtester.utils.Conditions.is;
+import static info.novatec.testit.webtester.utils.Conditions.present;
+
+import org.openqa.selenium.ElementNotVisibleException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+import info.novatec.testit.webtester.api.callbacks.PageObjectCallback;
+import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
+import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.StaleElementRecoveryException;
+import info.novatec.testit.webtester.eventsystem.EventSystem;
+import info.novatec.testit.webtester.eventsystem.events.browser.ExceptionEvent;
+import info.novatec.testit.webtester.pageobjects.PageObject;
+import info.novatec.testit.webtester.utils.Invalidator;
+import info.novatec.testit.webtester.utils.Waits;
+
+
+/**
+ * This class is used to execute 'actions' of {@link PageObject page objects} and handle some error cases by default.
+ * <p>
+ * An action can be as simple as executing a click on a button or more complex like selecting a value of drop down menu.
+ * In general these actions are executed on {@link org.openqa.selenium.WebElement web elements}. This executions throw
+ * certain exceptions in special cases (like {@link StaleElementReferenceException}. In order to handle these exceptional
+ * cases in a default way this template was created.
+ * <p>
+ * It offers two distinct methods:
+ * <ol>
+ * <li>{@link #executeAction(PageObjectCallback)}</li>
+ * <li>{@link #executeAction(PageObjectCallbackWithReturnValue)}</li>
+ * </ol>
+ *
+ * @since 1.1.0
+ */
+@Internal
+@SuppressWarnings("PMD.AvoidCatchingGenericException")
+public class ActionTemplate {
+
+    private static final Logger logger = LoggerFactory.getLogger(ActionTemplate.class);
+
+    private PageObject pageObject;
+
+    public ActionTemplate(PageObject pageObject) {
+        this.pageObject = pageObject;
+    }
+
+    /**
+     * Execute the given callback and handle exceptional cases.
+     * <ul>
+     * <li>{@link StaleElementReferenceException}
+     * - try to recover by invalidating the page object and retrying the same operation</li>
+     * <li>{@link ElementNotVisibleException}
+     * - throw new {@link PageObjectIsInvisibleException} as well as fire exception event</li>
+     * <li>{@link RuntimeException}
+     * - fire exception event and rethrow the original exception</li>
+     * </ul>
+     *
+     * @param callback the callback to execute
+     * @throws StaleElementRecoveryException in case a {@link StaleElementReferenceException} could not be recovered from
+     * @throws PageObjectIsInvisibleException in case the subject of the callback is invisible
+     * @since 1.1.0
+     */
+    public void executeAction(PageObjectCallback callback) {
+        try {
+            callback.execute(pageObject);
+        } catch (StaleElementReferenceException e) {
+            logStaleElementRecoveryAttempt(e);
+            tryToResolveStaleElementException(callback);
+        } catch (ElementNotVisibleException e) {
+            throw fireExceptionEventAndReturn(new PageObjectIsInvisibleException(pageObject, e));
+        } catch (RuntimeException e) {
+            throw fireExceptionEventAndReturn(e);
+        }
+    }
+
+    /**
+     * Execute the given callback, returns the callbacks return value and handle exceptional cases.
+     * <ul>
+     * <li>{@link StaleElementReferenceException}
+     * - try to recover by invalidating the page object and retrying the same operation</li>
+     * <li>{@link ElementNotVisibleException}
+     * - throw new {@link PageObjectIsInvisibleException} as well as fire exception event</li>
+     * <li>{@link RuntimeException}
+     * - fire exception event and rethrow the original exception</li>
+     * </ul>
+     *
+     * @param callback the callback to execute
+     * @return the return value of the callback
+     * @throws StaleElementRecoveryException in case a {@link StaleElementReferenceException} could not be recovered from
+     * @throws PageObjectIsInvisibleException in case the subject of the callback is invisible
+     * @since 1.1.0
+     */
+    public <B> B executeAction(PageObjectCallbackWithReturnValue<B> callback) {
+        B value;
+        try {
+            value = callback.execute(pageObject);
+        } catch (StaleElementReferenceException e) {
+            logStaleElementRecoveryAttempt(e);
+            value = tryToResolveStaleElementException(callback);
+        } catch (ElementNotVisibleException e) {
+            throw fireExceptionEventAndReturn(new PageObjectIsInvisibleException(pageObject, e));
+        } catch (RuntimeException e) {
+            throw fireExceptionEventAndReturn(e);
+        }
+        return value;
+    }
+
+    private void tryToResolveStaleElementException(PageObjectCallback callback) {
+        try {
+            refreshAndWaitOnPageObjectsPresence();
+            callback.execute(pageObject);
+            logStaleElementRecoverySuccess();
+        } catch (RuntimeException e) {
+            handleStaleElementRecoveryFailure(e);
+        }
+    }
+
+    private <B> B tryToResolveStaleElementException(PageObjectCallbackWithReturnValue<B> callback) {
+        B value = null;
+        try {
+            refreshAndWaitOnPageObjectsPresence();
+            value = callback.execute(pageObject);
+            logStaleElementRecoverySuccess();
+        } catch (RuntimeException e) {
+            handleStaleElementRecoveryFailure(e);
+        }
+        return value;
+    }
+
+    private void refreshAndWaitOnPageObjectsPresence() {
+        Waits.waitUntil(Invalidator.invalidate(pageObject), is(present()));
+    }
+
+    private void logStaleElementRecoveryAttempt(StaleElementReferenceException e) {
+        logger.trace("trying to resolve stale element exception", e);
+    }
+
+    private void logStaleElementRecoverySuccess() {
+        logger.trace("succeeded in resolving stale element exception");
+    }
+
+    private void handleStaleElementRecoveryFailure(RuntimeException e) {
+        logger.trace("failed in resolving stale element exception");
+        throw fireExceptionEventAndReturn(new StaleElementRecoveryException(e));
+    }
+
+    private <T extends RuntimeException> T fireExceptionEventAndReturn(T exception) {
+        EventSystem.fireEvent(new ExceptionEvent(pageObject, exception));
+        return exception;
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/pageobjects/DefaultPageObjectFactory.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/pageobjects/DefaultPageObjectFactory.java
@@ -51,7 +51,7 @@ import info.novatec.testit.webtester.utils.Waits;
  * via a constructor!
  */
 @Internal
-@SuppressWarnings({ "unchecked", "PMD.AvoidCatchingGenericException" })
+@SuppressWarnings("unchecked")
 public final class DefaultPageObjectFactory implements PageObjectFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultPageObjectFactory.class);
@@ -65,6 +65,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public <T extends PageObject> T create(Class<T> pageClazz, PageObjectModel model, WebElement webElement) {
 
         try {
@@ -98,7 +99,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
         try {
             Constructor<T> classConstructor = pageClazz.getDeclaredConstructor();
             return ReflectionUtils.forceCreateInstance(classConstructor);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException e) {
             throw exception(pageClazz, e).inConstructor();
         }
     }
@@ -107,7 +108,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
         try {
             Field field = PageObject.class.getDeclaredField(FIELD_NAME_MODEL);
             ReflectionUtils.forceSetField(field, pageInstance, model);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException e) {
             throw exception(pageInstance, e).inModelFieldInjection();
         }
     }
@@ -116,7 +117,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
         try {
             Field field = PageObject.class.getDeclaredField(FIELD_NAME_WEB_ELEMENT);
             ReflectionUtils.forceSetField(field, pageInstance, webElement);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException e) {
             throw exception(pageInstance, e).inWebElementFieldInjection();
         }
     }
@@ -164,7 +165,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
         try {
             PageObject pageObject = create(( Class<? extends PageObject> ) field.getType(), metaData);
             ReflectionUtils.forceSetField(field, pageInstance, pageObject);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             throw exception(pageInstance, e).inPageObjectFieldInjection(field);
         }
 
@@ -183,7 +184,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
         try {
             PageObjectList<? extends PageObject> pageObjectList = new LazyLoadingPageObjectList(listType, listMetaData);
             ReflectionUtils.forceSetField(field, pageInstance, pageObjectList);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             throw exception(pageInstance, e).inPageObjectFieldInjection(field);
         }
 
@@ -216,7 +217,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
     private <T extends PageObject> void tryToInvokePostConstructMethod(T pageInstance, Method method) {
         try {
             ReflectionUtils.forceInvokeMethod(method, pageInstance);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException e) {
             throw exception(pageInstance, e).whenExecutingPostConstructMethod(method);
         }
     }
@@ -271,7 +272,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
     private <T extends PageObject> void tryToWaitOnPageObjectsVisibility(T pageInstance, Field field) {
         try {
             waitOnPageObjectsVisibility(pageInstance, field);
-        } catch (RuntimeException e) {
+        } catch (TimeoutException e) {
             throw exception(pageInstance, e).whenWaitingForVisibilityOfPageObjectField(field);
         }
     }
@@ -284,7 +285,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
     private <T extends PageObject> void tryToWaitOnPageObjectListVisibility(T pageInstance, Field field) {
         try {
             waitOnPageObjectListsVisibility(pageInstance, field);
-        } catch (RuntimeException e) {
+        } catch (IllegalStateException e) {
             throw exception(pageInstance, e).whenWaitingForVisibilityOfPageObjectListField(field);
         }
     }
@@ -315,7 +316,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
     private <T extends PageObject> PageObject getPageObjectFromOf(Field field, T pageInstance) {
         try {
             return ( PageObject ) ReflectionUtils.forceGetFieldValue(field, pageInstance);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             throw exception(pageInstance, e).whenGettingPageObjectField(field);
         }
     }
@@ -323,7 +324,7 @@ public final class DefaultPageObjectFactory implements PageObjectFactory {
     private <T extends PageObject> PageObjectList<PageObject> getPageObjectListFromOf(Field field, T pageInstance) {
         try {
             return ( PageObjectList<PageObject> ) ReflectionUtils.forceGetFieldValue(field, pageInstance);
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             throw exception(pageInstance, e).whenGettingPageObjectListField(field);
         }
     }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/utils/Invalidator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/utils/Invalidator.java
@@ -36,11 +36,13 @@ public final class Invalidator {
     /**
      * Invalidates a list of {@link PageObject page objects}.
      *
+     * @param <T> the type of the page object list to invalidate
      * @param pageObjectList the list to invalidate
-     * @since 0.9.3
+     * @return the same page object list for fluent API use
+     * @since 1.1.0
      */
     @SuppressWarnings("rawtypes")
-    public static void invalidate(List<? extends PageObject> pageObjectList) {
+    public static <T extends PageObject> List<T> invalidate(List<T> pageObjectList) {
         if (pageObjectList instanceof PageObjectList) {
             (( PageObjectList ) pageObjectList).invalidate();
         } else {
@@ -48,6 +50,7 @@ public final class Invalidator {
                 invalidate(pageObject);
             }
         }
+        return pageObjectList;
     }
 
     /**
@@ -56,14 +59,17 @@ public final class Invalidator {
      * and calling {@link PageObject#invalidate() invalidate()} on each page
      * object or {@link LazyLoadingPageObjectList page object list} instance.
      *
+     * @param <T> the type of the page object to invalidate
      * @param pageObject the page object whose sub elements should be invalidated
-     * @since 0.9.3
+     * @return the same page object instance for fluent API use
+     * @since 1.1.0
      */
-    public static void invalidate(PageObject pageObject) {
+    public static <T extends PageObject> T invalidate(T pageObject) {
         Deque<Class<?>> classStack = ReflectionUtils.getClassAncestry(pageObject.getClass());
         while (!classStack.isEmpty()) {
             invalidatePageObjectsFieldsOfClass(pageObject, classStack.pop());
         }
+        return pageObject;
     }
 
     @SuppressWarnings("rawtypes")

--- a/webtester-core/src/test/java/utils/StaticFieldReplacer.java
+++ b/webtester-core/src/test/java/utils/StaticFieldReplacer.java
@@ -22,7 +22,7 @@ public class StaticFieldReplacer extends ExternalResource {
     }
 
     @Override
-    public void before() throws IllegalAccessException, NoSuchFieldException {
+    public void before() throws ReflectiveOperationException {
         original = ReflectionUtils.forceGetFieldValue(clazz, fieldName);
         ReflectionUtils.forceSetField(clazz, fieldName, replacement);
     }

--- a/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/WebTesterJUnitRunner.java
+++ b/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/WebTesterJUnitRunner.java
@@ -176,7 +176,7 @@ public class WebTesterJUnitRunner extends BlockJUnit4ClassRunner {
                 }
             }
 
-            private void executeBeforeClassForAllBrowsers() throws IllegalAccessException {
+            private void executeBeforeClassForAllBrowsers() throws ReflectiveOperationException {
                 for (ClassTestBrowser browser : classBrowsers) {
                     browser.beforeClass();
                 }
@@ -253,7 +253,7 @@ public class WebTesterJUnitRunner extends BlockJUnit4ClassRunner {
                 }
             }
 
-            private void executeBeforeTestForAllBrowsers() throws IllegalAccessException {
+            private void executeBeforeTestForAllBrowsers() throws ReflectiveOperationException {
                 for (ClassTestBrowser browser : classBrowsers) {
                     browser.beforeTest();
                 }

--- a/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/AbstractTestBrowser.java
+++ b/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/AbstractTestBrowser.java
@@ -2,13 +2,11 @@ package info.novatec.testit.webtester.junit.runner.internal;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.lang.reflect.UndeclaredThrowableException;
 
 import org.apache.commons.lang.StringUtils;
 
 import info.novatec.testit.webtester.api.browser.Browser;
 import info.novatec.testit.webtester.api.browser.ProxyConfiguration;
-import info.novatec.testit.webtester.internal.annotations.Java7FeaturePossibility;
 import info.novatec.testit.webtester.junit.annotations.CreateUsing;
 import info.novatec.testit.webtester.junit.annotations.EntryPoint;
 import info.novatec.testit.webtester.junit.annotations.KeepAlive;
@@ -52,11 +50,11 @@ public abstract class AbstractTestBrowser {
         return this.field.getAnnotation(annotationClass) != null;
     }
 
-    protected void createBrowserAndSetStaticField() throws IllegalAccessException {
+    protected void createBrowserAndSetStaticField() throws ReflectiveOperationException {
         createBrowserIfNecessary(null);
     }
 
-    protected void createBrowserIfNecessary(Object target) throws IllegalAccessException {
+    protected void createBrowserIfNecessary(Object target) throws ReflectiveOperationException {
         Object fieldValue = field.get(target);
         if (fieldValue != null) {
             browser = ( Browser ) fieldValue;
@@ -66,22 +64,12 @@ public abstract class AbstractTestBrowser {
         }
     }
 
-    @Java7FeaturePossibility("Both Exceptions could be cought using ReflectiveOperationException type.")
-    private Browser createNewBrowser() {
-        try {
-
-            CreateUsing annotation = field.getAnnotation(CreateUsing.class);
-            if (annotation == null) {
-                throw new NoBrowserFactoryProvidedException();
-            }
-
-            return createNewBrowserFromAnnotation(annotation);
-
-        } catch (InstantiationException e) {
-            throw new UndeclaredThrowableException(e);
-        } catch (IllegalAccessException e) {
-            throw new UndeclaredThrowableException(e);
+    private Browser createNewBrowser() throws ReflectiveOperationException {
+        CreateUsing annotation = field.getAnnotation(CreateUsing.class);
+        if (annotation == null) {
+            throw new NoBrowserFactoryProvidedException();
         }
+        return createNewBrowserFromAnnotation(annotation);
     }
 
     private Browser createNewBrowserFromAnnotation(CreateUsing annotation)
@@ -117,7 +105,7 @@ public abstract class AbstractTestBrowser {
         }
     }
 
-    public abstract void beforeTest() throws IllegalAccessException;
+    public abstract void beforeTest() throws ReflectiveOperationException;
 
     public abstract void afterTest();
 

--- a/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/ClassTestBrowser.java
+++ b/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/ClassTestBrowser.java
@@ -14,7 +14,7 @@ public class ClassTestBrowser extends AbstractTestBrowser {
         super(browserField);
     }
 
-    public void beforeClass() throws IllegalAccessException {
+    public void beforeClass() throws ReflectiveOperationException {
         LOGGER.debug("beforeClass");
         createBrowserAndSetStaticField();
     }

--- a/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/ConfigurationValueInjector.java
+++ b/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/ConfigurationValueInjector.java
@@ -20,7 +20,7 @@ public final class ConfigurationValueInjector {
         void injectInto(Configuration config, String key, Field field, Object target) throws IllegalAccessException;
     }
 
-    private static final String UNINJECTABLE_FIELD_TYPE = "connot inject configuration values into fields of type ";
+    private static final String UNINJECTABLE_FIELD_TYPE = "cannot inject configuration values into fields of type ";
     private static final Object STATIC_TARGET = null;
 
     private static final Map<Class<?>, Injector> INJECTOR_MAP = new HashMap<Class<?>, Injector>();
@@ -127,8 +127,8 @@ public final class ConfigurationValueInjector {
         try {
             injector.injectInto(config, configurationValue.value(), field, target);
         } catch (IllegalAccessException e) {
-            /* since fields are set accessible at the beginning of this method
-             * IllegalAccessExceptions should not occur! */
+            /* since fields are set accessible at the beginning of this method  IllegalAccessExceptions should not occur.
+             * That makes it ok to throw an UndeclaredThrowableException */
             throw new UndeclaredThrowableException(e);
         }
 

--- a/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/MethodTestBrowser.java
+++ b/webtester-support-junit/src/main/java/info/novatec/testit/webtester/junit/runner/internal/MethodTestBrowser.java
@@ -18,7 +18,7 @@ public class MethodTestBrowser extends AbstractTestBrowser {
     }
 
     @Override
-    public void beforeTest() throws IllegalAccessException {
+    public void beforeTest() throws ReflectiveOperationException {
         LOGGER.debug("beforeTest");
         createBrowserIfNecessary(target);
         openEntryPointIfSet();


### PR DESCRIPTION
ee07a84 Fixes some JavaDoc warnings and renamed non-conventional named Generic Types

75b5593 Moved the action template logic from the PageObject class to a stand alone class. This reduces the overall size of the PageObject class as well as provides a means to use the template outside of that particular context.

070144d Replaces multiple reflection based exceptions with Single ReflectiveOperationException of Java 7

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester-core/9)
<!-- Reviewable:end -->
