### PR TITLE
added context-click, modified eclipse-formatter

### DIFF
--- a/development/eclipse_formatter.xml
+++ b/development/eclipse_formatter.xml
@@ -33,7 +33,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
@@ -61,7 +61,7 @@
 <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
@@ -205,7 +205,7 @@
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
@@ -261,7 +261,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
@@ -274,7 +274,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
@@ -289,7 +289,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="125"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
 </profile>
 </profiles>

--- a/documentation/chapters/mouse.md
+++ b/documentation/chapters/mouse.md
@@ -6,6 +6,7 @@ The `Mouse` utility class contains all kinds of methods which allow you to use o
 
 - `click(PageObject)`
 - `doubleClick(PageObject)`
+- `contextClick(PageObject)`
 - `moveTo(PageObject)`
 - `moveToEach(PageObject, PageObject...)`
 - `moveToEach(Collection<PageObject>)`
@@ -15,6 +16,9 @@ Executes a click on the given `PageObject` by first moving the mouse to the cent
 
 ## Mouse.doubleClick()
 Executes a double click on the given `PageObject` by first moving the mouse to the center of it.
+
+## Mouse.contextClick()
+Executes a context click on the given `PageObject` by first moving the mouse to the center of it.
 
 ## Mouse.moveToEach()
 Moves the mouse to each of the given `PageObject`s in turn. The page objects have to be visible in order to move

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/eventsystem/events/pageobject/ContextClickedEvent.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/eventsystem/events/pageobject/ContextClickedEvent.java
@@ -7,21 +7,21 @@ import info.novatec.testit.webtester.pageobjects.PageObject;
 
 
 /**
- * This {@link Event event} occurs whenever a double click is executed on an
+ * This {@link Event event} occurs whenever a context click is executed on an
  * element.
  *
- * @since 0.9.0
+ * @since 1.1.0
  */
 @SuppressWarnings("serial")
-public class DoubleClickedEvent extends AbstractPageObjectEvent {
+public class ContextClickedEvent extends AbstractPageObjectEvent {
 
-    public DoubleClickedEvent(PageObject pageObject) {
+    public ContextClickedEvent(PageObject pageObject) {
         super(pageObject);
     }
 
     @Override
     public String getEventMessage() {
-        return format("double clicked on %s", getSubjectName());
+        return format("context clicked on %s", getSubjectName());
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/utils/Mouse.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/utils/Mouse.java
@@ -15,6 +15,7 @@ import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledExceptio
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
 import info.novatec.testit.webtester.eventsystem.EventSystem;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.ClickedEvent;
+import info.novatec.testit.webtester.eventsystem.events.pageobject.ContextClickedEvent;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.DoubleClickedEvent;
 import info.novatec.testit.webtester.pageobjects.PageObject;
 
@@ -72,6 +73,33 @@ public final class Mouse {
             public void execute(PageObject po) {
                 startActionSequence(po).doubleClick(po.getWebElement()).perform();
                 EventSystem.fireEvent(new DoubleClickedEvent(po));
+                Marker.markAsUsed(po);
+            }
+
+        });
+    }
+
+    /**
+     * Executes a single context-click on the given {@linkplain PageObject page
+     * object}. Will throw an exception if the page object is disabled or
+     * invisible!
+     * <p>
+     * The actual behavior might vary between different {@link WebDriver}
+     * implementations. Some implementations might move the actual mouse cursor,
+     * some might simulate the behavior.
+     *
+     * @param pageObject the page object the context-click should be executed on
+     * @throws PageObjectIsDisabledException if the page object is disabled
+     * @throws PageObjectIsInvisibleException if the page object is invisible
+     * @since 1.1.0
+     */
+    public static void contextClick(PageObject pageObject) {
+        pageObject.executeAction(new PageObjectCallback() {
+
+            @Override
+            public void execute(PageObject po) {
+                startActionSequence(po).contextClick(po.getWebElement()).perform();
+                EventSystem.fireEvent(new ContextClickedEvent(po));
                 Marker.markAsUsed(po);
             }
 

--- a/webtester-core/src/test/java/integration/utils/MouseIntegrationTest.java
+++ b/webtester-core/src/test/java/integration/utils/MouseIntegrationTest.java
@@ -7,12 +7,11 @@ import javax.annotation.PostConstruct;
 
 import org.junit.Test;
 
-import integration.AbstractWebTesterIntegrationTest;
-
 import info.novatec.testit.webtester.api.annotations.IdentifyUsing;
 import info.novatec.testit.webtester.pageobjects.Button;
 import info.novatec.testit.webtester.pageobjects.PageObject;
 import info.novatec.testit.webtester.utils.Mouse;
+import integration.AbstractWebTesterIntegrationTest;
 
 
 public class MouseIntegrationTest extends AbstractWebTesterIntegrationTest {
@@ -64,6 +63,19 @@ public class MouseIntegrationTest extends AbstractWebTesterIntegrationTest {
 
     }
 
+    @Test
+    public void testThatContextClickingAPageObjectWithTheMouseIsPossible() {
+
+        MoveTestPage page = getBrowser().create(MoveTestPage.class);
+
+        /* Context click the context click button. */
+        Mouse.contextClick(page.clickContextClickButton);
+
+        /* The target button should now be displayed after. */
+        assertThat(page.clickTargetButton.isVisible(), is(true));
+
+    }
+
     public static class MoveTestPage extends PageObject {
 
         @IdentifyUsing("moveTo_startButton")
@@ -77,6 +89,8 @@ public class MouseIntegrationTest extends AbstractWebTesterIntegrationTest {
         Button clickSingleClickButton;
         @IdentifyUsing("click_doubleClickButton")
         Button clickDoubleClickButton;
+        @IdentifyUsing("click_contextClickButton")
+        Button clickContextClickButton;
         @IdentifyUsing("click_targetButton")
         Button clickTargetButton;
 

--- a/webtester-core/src/test/resources/html/utils/mouse.html
+++ b/webtester-core/src/test/resources/html/utils/mouse.html
@@ -79,6 +79,11 @@
 		ondblclick="displayButton('click_targetButton')">
 			Click: Double Click Button
 	</button>
+	<button 
+		id="click_contextClickButton"
+		oncontextmenu="displayButton('click_targetButton'); return false">
+			Click: Context Click Button
+	</button>
 	<br><br>
 	<button 
 		id="click_targetButton"


### PR DESCRIPTION
Added simulated context-click and integration-test;
modified eclipse-formatter:
-no indent javadoc-tags
-no whitespace before&after opening parenthesis in annotations
-no whitespace before closing parenthesis in annotations
-no whitespace after constructor- and methods-name 