### PR TITLE
Added method for pressing the ENTER key on text fields and a warning on problematic methods

### DIFF
--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TextField.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TextField.java
@@ -3,6 +3,7 @@ package info.novatec.testit.webtester.pageobjects;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +13,7 @@ import com.google.common.collect.Sets;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallback;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.StaleElementRecoveryException;
 import info.novatec.testit.webtester.api.pageobjects.traits.HasText;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.TextAppendedEvent;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.TextClearedEvent;
@@ -88,6 +90,11 @@ public class TextField extends PageObject implements HasText {
     /**
      * Sets the given text by replacing whatever text is currently set for the
      * {@link TextField text field}.
+     * <p>
+     * <b>Note:</b> is is not advised to try and send {@link Keys} via this method!
+     * Doing so may in some cases lead to unintended side effects. I.e. sending ENTER
+     * to a search field will cause a {@link StaleElementRecoveryException} if this action
+     * navigates to another page.
      *
      * @param textToSet the text to set
      * @return the same instance for fluent API use
@@ -117,6 +124,11 @@ public class TextField extends PageObject implements HasText {
     /**
      * Appends the given text to whatever text is currently set for the
      * {@link TextField text field}.
+     * <p>
+     * <b>Note:</b> is is not advised to try and send {@link Keys} via this method!
+     * Doing so may in some cases lead to unintended side effects. I.e. sending ENTER
+     * to a search field will cause a {@link StaleElementRecoveryException} if this action
+     * navigates to another page.
      *
      * @param textToAppend the text to append
      * @return the same instance for fluent API use
@@ -140,6 +152,26 @@ public class TextField extends PageObject implements HasText {
 
         });
         return this;
+    }
+
+    /**
+     * Presses enter on this text field. This can be for example be used to send a form where the text
+     * field is included.
+     * <p>
+     * This method does <u>not</u> return this instance for fluent API because pressing ENTER is usually done in
+     * order to send a form or otherwise execute a potentially terminal action.
+     *
+     * @since 1.1.0
+     */
+    public void pressEnter() {
+        executeAction(new PageObjectCallback() {
+
+            @Override
+            public void execute(PageObject pageObject) {
+                pageObject.getWebElement().sendKeys(Keys.ENTER);
+            }
+
+        });
     }
 
     @Override

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TextFieldTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TextFieldTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.apache.commons.lang.StringUtils;
@@ -16,6 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
+import org.openqa.selenium.Keys;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
@@ -201,6 +203,15 @@ public class TextFieldTest extends AbstractPageObjectTest {
     public void testThatAppendingTextOnDisabledFieldThrowsException() {
         elementIsDisabled();
         cut.appendText("foo");
+    }
+
+    /* pressing ENTER */
+
+    @Test
+    public void testThatPressingEnterSendsCorrectKey() {
+        cut.pressEnter();
+        verify(webElement).sendKeys(Keys.ENTER);
+        verifyNoMoreInteractions(webElement);
     }
 
     /* correctness of class */


### PR DESCRIPTION
See #17 for reasons.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester-core/21)
<!-- Reviewable:end -->
