### PR TITLE
Mapping based validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
 before_script:

--- a/documentation/chapters/page-object-functional.md
+++ b/documentation/chapters/page-object-functional.md
@@ -10,6 +10,43 @@ In contrast to the generic interactions offered by Selenium's `WebElement` inter
 only provide methods which are useful for the given context / their type. A `Select` does not provide methods to change its text, 
 but it will have methods to change selection based on index, value or text.
 
+## Validation of Page Objects
+By default page objects will match any HTML tag in form of a WebElement. Functional page objects on the other hand are 
+limited to a certain amount of valid HTML tags and attribute combinations. This is done by annotating them with 
+```@Mapping``` or ```@Mappings``` in case there is more then one valid combination.
+
+Annotating any page object with ```@Mapping``` will trigger a validation logic anytime the underlying web element is 
+resolved. Depending on the cache level of the page object this will be the first (Caching = ON) or every (Caching = OFF) 
+time an interaction method is called. In case the validation fails a ```WrongElementClassException``` is thrown.
+
+### @Mapping
+The ```@Mapping``` annotation is used to define a valid combination of tag, attribute and attribute values of a web 
+element to be used with a page object class.
+
+**There are a number of different ways to use this:**
+
+* ```@Mapping(tag="div")``` Will be evaluated as 'valid' in case the web element has the tag 'div'.
+* ```@Mapping(tag="select", attribute="multiple")``` Will be evaluated as 'valid' in case the web element has the tag 
+'select' and the 'multiple' attribute is
+present.
+* ```@Mapping(tag="select", attribute="!multiple")``` Will be evaluated as 'valid' in case the web element has the tag 
+'select' and the 'multiple' attribute is not present.
+* ```@Mapping(tag="input", attribute="type", values={"text", "password"})``` Will be evaluated as 'valid' in case the web 
+element has the tag 'input' and the 'type' attribute has either the 'text' oder 'password' value.
+* ```@Mapping(validator=FooValidator.class)``` Will create a new instance of the given validator class and use it to 
+evaluate the web element.
+
+### @Mappings
+The ```@Mappings``` annotation is a grouping annotation that can combine a number of ```@Mapping``` annotations.
+
+**Example:***
+```java
+@Mappings({@Mapping(tag="h1", @Mapping(tag="h2")})
+public class Headline extends PageObject {
+    /// this page object will be valid for 'h1' and 'h2' tags
+}
+```
+
 ## Button
 **Extends:** PageObject
 

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/annotations/Mapping.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/annotations/Mapping.java
@@ -1,0 +1,67 @@
+package info.novatec.testit.webtester.api.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import info.novatec.testit.webtester.internal.validation.NoOpValidator;
+import info.novatec.testit.webtester.api.pageobjects.Validator;
+
+
+/**
+ * This annotation can be applied an {@link info.novatec.testit.webtester.pageobjects.PageObject page object} classes
+ * and will be evaluated when checking the page object's class mapping. This check will be executed whenever the actual
+ * {@link org.openqa.selenium.WebElement web element} is retrieved from a page object.
+ * <p>
+ * There are several ways of using this annotation:
+ * <dl>
+ * <dt><b>@Mapping(tag="div")</b></dt>
+ * <dd>Will be evaluated as 'valid' in case the web element has the tag 'div'.</dd>
+ * <dt><b>@Mapping(tag="select", attribute="multiple")</b></dt>
+ * <dd>Will be evaluated as 'valid' in case the web element has the tag 'select' and the 'multiple' attribute is
+ * present.</dd>
+ * <dt><b>@Mapping(tag="select", attribute="!multiple")</b></dt>
+ * <dd>Will be evaluated as 'valid' in case the web element has the tag 'select' and the 'multiple' attribute is not
+ * present.</dd>
+ * <dt><b>@Mapping(tag="input", attribute="type", values={"text", "password"})</b></dt>
+ * <dd>Will be evaluated as 'valid' in case the web element has the tag 'input' and the 'type' attribute has either the
+ * 'text' oder 'password' value.</dd>
+ * <dt><b>@Mapping(validator=FooValidator.class)</b></dt>
+ * <dd>Will create a new instance of the given validator class and use it to evaluate the web element.</dd>
+ * </dl>
+ *
+ * @since 1.2.0
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Mapping {
+
+    /**
+     * @return the valid tag for this {@link Mapping}
+     * @since 1.2.0
+     */
+    String tag() default "";
+
+    /**
+     * @return the name of the attribute that needs to be present for this {@link Mapping} - might be negated by prefixing
+     * the attribute's name with a '!'.
+     * @since 1.2.0
+     */
+    String attribute() default "";
+
+    /**
+     * @return a number of valid values for the given attribute
+     * @since 1.2.0
+     */
+    String[] values() default {};
+
+    /**
+     * @return tha validator class to use when evaluating the web element
+     * @since 1.2.0
+     */
+    Class<? extends Validator> validator() default NoOpValidator.class;
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/annotations/Mappings.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/annotations/Mappings.java
@@ -1,0 +1,28 @@
+package info.novatec.testit.webtester.api.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * This meta annotation can be used to annotate a {@link info.novatec.testit.webtester.pageobjects.PageObject} with multiple
+ * {@link Mapping} annotations.
+ *
+ * @see Mapping
+ * @since 1.2.0
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Mappings {
+
+    /**
+     * @return a number of grouped {@link Mapping} annotations
+     * @since 1.2.0
+     */
+    Mapping[] value();
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/exceptions/WrongElementClassException.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/exceptions/WrongElementClassException.java
@@ -17,7 +17,11 @@ import info.novatec.testit.webtester.pageobjects.TextField;
 public class WrongElementClassException extends WebTesterException {
 
     public WrongElementClassException(Class<?> expectedClass) {
-        super(String.format("element is not a %s!", expectedClass));
+        super(String.format("element is not a valid %s!", expectedClass));
+    }
+
+    public WrongElementClassException(String message) {
+        super(message);
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/pageobjects/Validator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/pageobjects/Validator.java
@@ -1,0 +1,36 @@
+package info.novatec.testit.webtester.api.pageobjects;
+
+import org.openqa.selenium.WebElement;
+
+import info.novatec.testit.webtester.api.annotations.Mapping;
+import info.novatec.testit.webtester.pageobjects.PageObject;
+
+
+/**
+ * Validators are used to validate {@link WebElement web elements} for {@link PageObject page objects}. They 
+ * provide a way to implement more complex validation logic then the {@link Mapping @Mapping} annotation con provide on it's own.
+ *
+ * @since 1.2.0
+ */
+public interface Validator {
+
+    /**
+     * Validates if the given {@link WebElement web element} is valid for being used as a specific {@link PageObject page
+     * object}.
+     *
+     * @param webElement the web element to validate
+     * @return true if the web element is valid, otherwise false
+     * @since 1.2.0
+     */
+    boolean isValid(WebElement webElement);
+
+    /**
+     * Returns a textual description of this validator. It is used in case all validators of a page object fail to describe
+     * what valida the constellations are.
+     *
+     * @return a textual description of this validator
+     * @since 1.2.0
+     */
+    String describe();
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/MappingValidator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/MappingValidator.java
@@ -1,0 +1,115 @@
+package info.novatec.testit.webtester.internal.validation;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.openqa.selenium.WebElement;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+import info.novatec.testit.webtester.api.annotations.Mapping;
+import info.novatec.testit.webtester.api.annotations.Mappings;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
+import info.novatec.testit.webtester.api.pageobjects.Validator;
+
+
+/**
+ * Allows for the validation of {@link WebElement web elements} for a {@link info.novatec.testit.webtester.pageobjects.PageObject
+ * page object} instance by the {@link Mapping} annotations of it's class.
+ *
+ * @since 1.2.0
+ */
+@Internal
+public class MappingValidator {
+
+    private final Class<?> type;
+    private final List<Validator> validConstellations;
+    private final List<String> validConstellationDescriptions;
+
+    public MappingValidator(Class<?> type) {
+        this.type = type;
+        this.validConstellations = extractValidationInformation(type);
+        this.validConstellationDescriptions = getValidConstellationDescriptions();
+    }
+
+    private static List<Validator> extractValidationInformation(Class<?> type) {
+
+        List<Mapping> mappings = new LinkedList<>();
+
+        if (type.isAnnotationPresent(Mapping.class)) {
+            mappings.add(type.getAnnotation(Mapping.class));
+        }
+
+        if (type.isAnnotationPresent(Mappings.class)) {
+            for (Mapping mapping : type.getAnnotation(Mappings.class).value()) {
+                mappings.add(mapping);
+            }
+        }
+
+        List<Validator> validConstellations = new LinkedList<>();
+        for (Mapping mapping : mappings) {
+            validConstellations.add(convertToValidConstellation(mapping));
+        }
+        return validConstellations;
+
+    }
+
+    private static Validator convertToValidConstellation(Mapping mapping) {
+        String tag = mapping.tag();
+        String attribute = mapping.attribute();
+        String[] values = mapping.values();
+        if (mapping.validator() != NoOpValidator.class) {
+            try {
+                return mapping.validator().newInstance();
+            } catch (InstantiationException | IllegalAccessException e) {
+                throw new UndeclaredThrowableException(e);
+            }
+        } else if (StringUtils.isNotBlank(attribute)) {
+            if (values.length > 0) {
+                return new TagAttributeValueValidator(tag, attribute, values);
+            } else if (attribute.charAt(0) == '!') {
+                String attributeName = attribute.substring(1);
+                return new TagAttributeNotPresentValidator(tag, attributeName);
+            } else {
+                return new TagAttributePresentValidator(tag, attribute);
+            }
+        } else {
+            return new TagValidator(tag);
+        }
+    }
+
+    private List<String> getValidConstellationDescriptions() {
+        List<String> descriptions = new LinkedList<>();
+        for (Validator constellation : validConstellations) {
+            descriptions.add(constellation.describe());
+        }
+        return descriptions;
+    }
+
+    public boolean canValidate() {
+        return !validConstellations.isEmpty();
+    }
+
+    public void assertValidity(WebElement webElement) {
+        if (validConstellations.isEmpty()) {
+            return;
+        }
+        boolean valid = false;
+        for (Validator constellation : validConstellations) {
+            if (constellation.isValid(webElement)) {
+                valid = true;
+                break;
+            }
+        }
+        if (!valid) {
+            throw new WrongElementClassException(getInvalidityMessage(webElement));
+        }
+    }
+
+    private String getInvalidityMessage(WebElement webElement) {
+        return webElement + " is not a valid web element for class: " + type + "\n\tValid elements include: \n\t - "
+            + StringUtils.join(validConstellationDescriptions, "\n\t - ");
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/NoOpValidator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/NoOpValidator.java
@@ -1,0 +1,29 @@
+package info.novatec.testit.webtester.internal.validation;
+
+import org.openqa.selenium.WebElement;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+import info.novatec.testit.webtester.api.annotations.Mapping;
+import info.novatec.testit.webtester.api.pageobjects.Validator;
+
+
+/**
+ * This is a {@link Validator} implementation that basically does nothing. It will return <code>true</code> for each call on
+ * {@link #isValid(WebElement)}. The main reason this class exists is to use it as a default in the {@link Mapping}
+ * annotation. In case this class is set on the annotation (default), the {@link MappingValidator} will use the annotation's
+ * properties to generate a validator instead of using this one.
+ */
+@Internal
+public class NoOpValidator implements Validator {
+
+    @Override
+    public boolean isValid(WebElement webElement) {
+        return true;
+    }
+
+    @Override
+    public String describe() {
+        return "NO-OP";
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagAttributeNotPresentValidator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagAttributeNotPresentValidator.java
@@ -1,0 +1,36 @@
+package info.novatec.testit.webtester.internal.validation;
+
+import org.openqa.selenium.WebElement;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+import info.novatec.testit.webtester.api.pageobjects.Validator;
+
+
+/**
+ * This {@link Validator} extends the {@link TagValidator} with a check on the NON-existence of a certain property.
+ * The property's value is not examined in any way.
+ * <p>
+ * <b>Example:</b> <code>@Mapping(tag="select", attribute="!multiple")</code>
+ */
+@Internal
+public class TagAttributeNotPresentValidator extends TagValidator {
+
+    private final String attributeName;
+
+    public TagAttributeNotPresentValidator(String tagName, String attributeName) {
+        super(tagName);
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    public boolean isValid(WebElement webElement) {
+        String attributeValue = webElement.getAttribute(attributeName);
+        return super.isValid(webElement) && attributeValue == null;
+    }
+
+    @Override
+    public String describe() {
+        return super.describe() + " and an attribute '" + attributeName + "' not being present";
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagAttributePresentValidator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagAttributePresentValidator.java
@@ -1,0 +1,36 @@
+package info.novatec.testit.webtester.internal.validation;
+
+import org.openqa.selenium.WebElement;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+import info.novatec.testit.webtester.api.pageobjects.Validator;
+
+
+/**
+ * This {@link Validator} extends the {@link TagValidator} with a check on the existence of a certain property.
+ * The property's value is not examined in any way.
+ * <p>
+ * <b>Example:</b> <code>@Mapping(tag="select", attribute="multiple")</code>
+ */
+@Internal
+public class TagAttributePresentValidator extends TagValidator {
+
+    private final String attributeName;
+
+    public TagAttributePresentValidator(String tagName, String attributeName) {
+        super(tagName);
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    public boolean isValid(WebElement webElement) {
+        String attributeValue = webElement.getAttribute(attributeName);
+        return super.isValid(webElement) && attributeValue != null;
+    }
+
+    @Override
+    public String describe() {
+        return super.describe() + " and an attribute '" + attributeName + "' present";
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagAttributeValueValidator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagAttributeValueValidator.java
@@ -1,0 +1,43 @@
+package info.novatec.testit.webtester.internal.validation;
+
+import java.util.Set;
+
+import org.openqa.selenium.WebElement;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+import info.novatec.testit.webtester.api.pageobjects.Validator;
+
+
+/**
+ * This {@link Validator} extends the {@link TagValidator} with a check on the value of a certain property.
+ * <p>
+ * <b>Example:</b> <code>@Mapping(tag="input", attribute="type", values={"", text})</code>
+ */
+@Internal
+public class TagAttributeValueValidator extends TagValidator {
+
+    private final String attributeName;
+    private final Set<String> validValues;
+
+    public TagAttributeValueValidator(String tagName, String attributeName, String[] values) {
+        super(tagName);
+        this.attributeName = attributeName;
+        this.validValues = ValidationUtils.toNormalizedSet(values);
+    }
+
+    @Override
+    public boolean isValid(WebElement webElement) {
+        String attributeValue = webElement.getAttribute(attributeName);
+        String normalizedAttributeValue = ValidationUtils.normalize(attributeValue);
+        // needed for text fields, since they are the default for input without type
+        boolean attributeValueNonNullOrEmptyAllowed = attributeValue != null || validValues.contains("");
+        return super.isValid(webElement) && attributeValueNonNullOrEmptyAllowed && validValues.contains(
+            normalizedAttributeValue);
+    }
+
+    @Override
+    public String describe() {
+        return super.describe() + " and an attribute '" + attributeName + "' with any value of " + validValues;
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagValidator.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/TagValidator.java
@@ -1,0 +1,34 @@
+package info.novatec.testit.webtester.internal.validation;
+
+import org.openqa.selenium.WebElement;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+import info.novatec.testit.webtester.api.pageobjects.Validator;
+
+
+/**
+ * This {@link Validator} checks the tag name of a {@link WebElement}.
+ * <p>
+ * <b>Example:</b> <code>@Mapping(tag="div")</code>
+ */
+@Internal
+public class TagValidator implements Validator {
+
+    private final String tagName;
+
+    public TagValidator(String tagName) {
+        this.tagName = tagName;
+    }
+
+    @Override
+    public boolean isValid(WebElement webElement) {
+        String elementTagName = webElement.getTagName();
+        return tagName.equalsIgnoreCase(elementTagName);
+    }
+
+    @Override
+    public String describe() {
+        return "Element having '" + tagName + "' as it's tag";
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/ValidationUtils.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/validation/ValidationUtils.java
@@ -1,0 +1,30 @@
+package info.novatec.testit.webtester.internal.validation;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+import info.novatec.testit.webtester.api.annotations.Internal;
+
+
+@Internal
+public final class ValidationUtils {
+
+    private ValidationUtils() {
+        // utility class constructor
+    }
+
+    public static Set<String> toNormalizedSet(String... values) {
+        Set<String> set = new HashSet<>();
+        for (String value : values) {
+            set.add(normalize(value));
+        }
+        return set;
+    }
+
+    public static String normalize(String value) {
+        return StringUtils.defaultString(value).toLowerCase();
+    }
+
+}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Button.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Button.java
@@ -1,12 +1,9 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.WebElement;
 
-import com.google.common.collect.Sets;
-
+import info.novatec.testit.webtester.api.annotations.Mapping;
+import info.novatec.testit.webtester.api.annotations.Mappings;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
 import info.novatec.testit.webtester.api.pageobjects.traits.HasLabel;
@@ -25,11 +22,9 @@ import info.novatec.testit.webtester.utils.Asserts;
  *
  * @since 0.9.0
  */
+@Mappings({ @Mapping(tag = "button"),
+    @Mapping(tag = "input", attribute = "type", values = { "submit", "reset", "button" }) })
 public class Button extends PageObject implements HasValue<String>, HasLabel {
-
-    private static final String BUTTON_TAG = "button";
-    private static final String INPUT_TAG = "input";
-    private static final Set<String> VALID_TYPES = Sets.newHashSet("reset", "submit", "button");
 
     /**
      * Retrieves the value of the {@link Button button}. If no value is set an
@@ -61,7 +56,7 @@ public class Button extends PageObject implements HasValue<String>, HasLabel {
     @Override
     public String getLabel() {
         // For buttons created with <input>, the value is shown as the label
-        if (INPUT_TAG.equalsIgnoreCase(getTagName())) {
+        if ("input".equalsIgnoreCase(getTagName())) {
             return getValue();
         }
         return StringUtils.defaultString(getVisibleText());
@@ -81,19 +76,6 @@ public class Button extends PageObject implements HasValue<String>, HasLabel {
         Asserts.assertEnabledAndVisible(this);
         super.click();
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-
-        String tagName = webElement.getTagName();
-        String type = StringUtils.defaultString(webElement.getAttribute("type")).toLowerCase();
-
-        if (INPUT_TAG.equalsIgnoreCase(tagName)) {
-            return VALID_TYPES.contains(type);
-        }
-
-        return BUTTON_TAG.equalsIgnoreCase(tagName);
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Checkbox.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Checkbox.java
@@ -1,9 +1,9 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallback;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
@@ -21,6 +21,7 @@ import info.novatec.testit.webtester.utils.Asserts;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "input", attribute = "type", values = "checkbox")
 public class Checkbox extends PageObject implements Selectable {
 
     private static final Logger logger = LoggerFactory.getLogger(Checkbox.class);
@@ -94,19 +95,6 @@ public class Checkbox extends PageObject implements Selectable {
         Asserts.assertEnabledAndVisible(this);
         super.click();
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-
-        String tagName = webElement.getTagName();
-        String type = webElement.getAttribute("type");
-
-        boolean isCorrectTag = "input".equalsIgnoreCase(tagName);
-        boolean isCorrectType = "checkbox".equalsIgnoreCase(type);
-
-        return isCorrectTag && isCorrectType;
-
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Div.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Div.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 
 
 /**
@@ -11,11 +11,7 @@ import org.openqa.selenium.WebElement;
  *
  * @since 0.9.9
  */
+@Mapping(tag = "div")
 public class Div extends PageObject {
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "div".equalsIgnoreCase(webElement.getTagName());
-    }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Form.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Form.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 
 
 /**
@@ -11,11 +11,7 @@ import org.openqa.selenium.WebElement;
  *
  * @since 0.9.9
  */
+@Mapping(tag = "form")
 public class Form extends PageObject {
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "form".equalsIgnoreCase(webElement.getTagName());
-    }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Headline.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Headline.java
@@ -1,11 +1,7 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import java.util.Set;
-
-import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.WebElement;
-
-import com.google.common.collect.Sets;
+import info.novatec.testit.webtester.api.annotations.Mapping;
+import info.novatec.testit.webtester.api.annotations.Mappings;
 
 
 /**
@@ -21,15 +17,8 @@ import com.google.common.collect.Sets;
  *
  * @since 0.9.0
  */
+@Mappings({ @Mapping(tag = "h1"), @Mapping(tag = "h2"), @Mapping(tag = "h3"), @Mapping(tag = "h4"), @Mapping(tag = "h5"),
+    @Mapping(tag = "h6") })
 public class Headline extends PageObject {
-
-    private static final Set<String> VALID_TAGS = Sets.newHashSet("h1", "h2", "h3", "h4", "h5", "h6");
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        String tagName = webElement.getTagName();
-        String lowerCaseTagName = StringUtils.defaultString(tagName).toLowerCase();
-        return VALID_TAGS.contains(lowerCaseTagName);
-    }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/IFrame.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/IFrame.java
@@ -1,8 +1,8 @@
 package info.novatec.testit.webtester.pageobjects;
 
 import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.WebElement;
 
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.pageobjects.traits.HasSourcePath;
 
 
@@ -14,6 +14,7 @@ import info.novatec.testit.webtester.api.pageobjects.traits.HasSourcePath;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "iframe")
 public class IFrame extends PageObject implements HasSourcePath {
 
     /**
@@ -26,11 +27,6 @@ public class IFrame extends PageObject implements HasSourcePath {
     @Override
     public String getSourcePath() {
         return StringUtils.defaultString(getAttribute("src"));
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "iframe".equalsIgnoreCase(webElement.getTagName());
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Image.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Image.java
@@ -3,8 +3,8 @@ package info.novatec.testit.webtester.pageobjects;
 import java.io.File;
 
 import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.WebElement;
 
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
@@ -21,6 +21,7 @@ import info.novatec.testit.webtester.utils.Asserts;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "img")
 public class Image extends PageObject implements HasSourcePath, HasFileName {
 
     /**
@@ -74,11 +75,6 @@ public class Image extends PageObject implements HasSourcePath, HasFileName {
         Asserts.assertEnabledAndVisible(this);
         super.click();
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "img".equalsIgnoreCase(webElement.getTagName());
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Link.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Link.java
@@ -1,7 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
-
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
 import info.novatec.testit.webtester.utils.Asserts;
@@ -15,6 +14,7 @@ import info.novatec.testit.webtester.utils.Asserts;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "a")
 public class Link extends PageObject {
 
     /**
@@ -31,11 +31,6 @@ public class Link extends PageObject {
         Asserts.assertEnabledAndVisible(this);
         super.click();
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "a".equalsIgnoreCase(webElement.getTagName());
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/List.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/List.java
@@ -1,14 +1,10 @@
 package info.novatec.testit.webtester.pageobjects;
 
 import java.util.Collections;
-import java.util.Set;
-
-import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.WebElement;
-
-import com.google.common.collect.Sets;
 
 import info.novatec.testit.webtester.api.annotations.IdentifyUsing;
+import info.novatec.testit.webtester.api.annotations.Mapping;
+import info.novatec.testit.webtester.api.annotations.Mappings;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 import info.novatec.testit.webtester.api.enumerations.Method;
 
@@ -22,9 +18,8 @@ import info.novatec.testit.webtester.api.enumerations.Method;
  *
  * @since 0.9.0
  */
+@Mappings({ @Mapping(tag = "ul"), @Mapping(tag = "ol") })
 public class List extends PageObject {
-
-    private static final Set<String> VALID_TAGS = Sets.newHashSet("ul", "ol");
 
     @IdentifyUsing(method = Method.XPATH, value = "./li")
     private java.util.List<ListItem> listItems;
@@ -79,13 +74,6 @@ public class List extends PageObject {
      */
     public Boolean isEmpty() {
         return listItems.isEmpty();
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        String tagName = StringUtils.defaultString(webElement.getTagName());
-        String lowerCasedTagName = tagName.toLowerCase();
-        return VALID_TAGS.contains(lowerCasedTagName);
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/ListItem.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/ListItem.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 
 
 /**
@@ -11,11 +11,7 @@ import org.openqa.selenium.WebElement;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "li")
 public class ListItem extends PageObject {
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "li".equalsIgnoreCase(webElement.getTagName());
-    }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/NumberField.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/NumberField.java
@@ -1,8 +1,8 @@
 package info.novatec.testit.webtester.pageobjects;
 
 import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.WebElement;
 
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
 import info.novatec.testit.webtester.api.pageobjects.traits.HasValue;
@@ -16,6 +16,7 @@ import info.novatec.testit.webtester.api.pageobjects.traits.HasValue;
  *
  * @since 0.9.3
  */
+@Mapping(tag = "input", attribute = "type", values = "number")
 public class NumberField extends TextField implements HasValue<Long> {
 
     /**
@@ -68,19 +69,6 @@ public class NumberField extends TextField implements HasValue<Long> {
         // Overridden for fluent API use
         super.appendText(textToAppend);
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-
-        String tagName = webElement.getTagName();
-        String type = webElement.getAttribute("type");
-
-        boolean isCorrectTag = "input".equalsIgnoreCase(tagName);
-        boolean isCorrectType = "number".equalsIgnoreCase(type);
-
-        return isCorrectTag && isCorrectType;
-
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/PasswordField.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/PasswordField.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 
 
 /**
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebElement;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "input", attribute = "type", values = { "password" })
 public class PasswordField extends TextField {
 
     @Override
@@ -32,19 +33,6 @@ public class PasswordField extends TextField {
         // Overridden for fluent API use
         super.appendText(textToAppend);
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-
-        String tagName = webElement.getTagName();
-        String type = webElement.getAttribute("type");
-
-        boolean isCorrectTag = "input".equalsIgnoreCase(tagName);
-        boolean isCorrectType = "password".equalsIgnoreCase(type);
-
-        return isCorrectTag && isCorrectType;
-
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/RadioButton.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/RadioButton.java
@@ -1,7 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
-
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
@@ -17,6 +16,7 @@ import info.novatec.testit.webtester.utils.Asserts;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "input", attribute = "type", values = "radio")
 public class RadioButton extends PageObject implements Selectable {
 
     /**
@@ -65,19 +65,6 @@ public class RadioButton extends PageObject implements Selectable {
         Asserts.assertEnabledAndVisible(this);
         super.click();
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-
-        String tagName = webElement.getTagName();
-        String type = webElement.getAttribute("type");
-
-        boolean isCorrectTag = "input".equalsIgnoreCase(tagName);
-        boolean isCorrectType = "radio".equalsIgnoreCase(type);
-
-        return isCorrectTag && isCorrectType;
-
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Select.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Select.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallback;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.SelectedByIndexEvent;
@@ -25,6 +26,7 @@ import info.novatec.testit.webtester.utils.Asserts;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "select")
 public class Select extends PageObject {
 
     private static final Logger logger = LoggerFactory.getLogger(Select.class);
@@ -368,11 +370,6 @@ public class Select extends PageObject {
     public void invalidate() {
         select = null;
         super.invalidate();
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "select".equalsIgnoreCase(webElement.getTagName());
     }
 
     private org.openqa.selenium.support.ui.Select getSelect() {

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Span.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Span.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 
 
 /**
@@ -11,11 +11,7 @@ import org.openqa.selenium.WebElement;
  *
  * @since 0.9.9
  */
+@Mapping(tag = "span")
 public class Span extends PageObject {
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "span".equalsIgnoreCase(webElement.getTagName());
-    }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Table.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/Table.java
@@ -3,9 +3,8 @@ package info.novatec.testit.webtester.pageobjects;
 import java.util.Collections;
 import java.util.List;
 
-import org.openqa.selenium.WebElement;
-
 import info.novatec.testit.webtester.api.annotations.IdentifyUsing;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 import info.novatec.testit.webtester.api.enumerations.Method;
 
@@ -18,6 +17,7 @@ import info.novatec.testit.webtester.api.enumerations.Method;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "table")
 public class Table extends PageObject {
 
     @IdentifyUsing(method = Method.XPATH, value = "./tr | ./*/tr")
@@ -91,8 +91,4 @@ public class Table extends PageObject {
         });
     }
 
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "table".equalsIgnoreCase(webElement.getTagName());
-    }
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TableField.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TableField.java
@@ -1,12 +1,7 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import java.util.Set;
-
-import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.WebElement;
-
-import com.google.common.collect.Sets;
-
+import info.novatec.testit.webtester.api.annotations.Mapping;
+import info.novatec.testit.webtester.api.annotations.Mappings;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 
 
@@ -20,9 +15,8 @@ import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnV
  *
  * @since 0.9.0
  */
+@Mappings({ @Mapping(tag = "th"), @Mapping(tag = "td") })
 public class TableField extends PageObject {
-
-    private static final Set<String> VALID_TAGS = Sets.newHashSet("th", "td");
 
     /**
      * Returns whether or not this {@link TableField field} is is a header field
@@ -40,13 +34,6 @@ public class TableField extends PageObject {
             }
 
         });
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        String tagName = StringUtils.defaultString(webElement.getTagName());
-        String lowerCasedTagName = tagName.toLowerCase();
-        return VALID_TAGS.contains(lowerCasedTagName);
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TableRow.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TableRow.java
@@ -3,9 +3,8 @@ package info.novatec.testit.webtester.pageobjects;
 import java.util.Collections;
 import java.util.List;
 
-import org.openqa.selenium.WebElement;
-
 import info.novatec.testit.webtester.api.annotations.IdentifyUsing;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallbackWithReturnValue;
 import info.novatec.testit.webtester.api.enumerations.Method;
 
@@ -19,6 +18,7 @@ import info.novatec.testit.webtester.api.enumerations.Method;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "tr")
 public class TableRow extends PageObject {
 
     @IdentifyUsing(method = Method.XPATH, value = "./th | ./td")
@@ -79,11 +79,6 @@ public class TableRow extends PageObject {
             }
 
         });
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "tr".equalsIgnoreCase(webElement.getTagName());
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TextArea.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TextArea.java
@@ -1,6 +1,6 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import org.openqa.selenium.WebElement;
+import info.novatec.testit.webtester.api.annotations.Mapping;
 
 
 /**
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebElement;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "textarea")
 public class TextArea extends TextField {
 
     /**
@@ -64,11 +65,6 @@ public class TextArea extends TextField {
         // Overridden for fluent API use
         super.appendText(textToAppend);
         return this;
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-        return "textarea".equalsIgnoreCase(webElement.getTagName());
     }
 
 }

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TextField.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/TextField.java
@@ -1,15 +1,11 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Sets;
-
+import info.novatec.testit.webtester.api.annotations.Mapping;
 import info.novatec.testit.webtester.api.callbacks.PageObjectCallback;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
@@ -37,6 +33,7 @@ import info.novatec.testit.webtester.utils.Asserts;
  *
  * @since 0.9.0
  */
+@Mapping(tag = "input", attribute = "type", values = { "", "text", "password", "number" })
 public class TextField extends PageObject implements HasText {
 
     private static final Logger logger = LoggerFactory.getLogger(TextField.class);
@@ -44,9 +41,6 @@ public class TextField extends PageObject implements HasText {
     private static final String CLEARED_TEXT = "changed text from '{}' to '{}' by clearing it";
     private static final String SET_TEXT = "changed text from '{}' to '{}' by trying to set it to '{}'";
     private static final String APPEND_TEXT = "changed text from '{}' to '{}' by trying to append '{}'";
-
-    private static final String INPUT_TAG = "input";
-    private static final Set<String> VALID_TYPES = Sets.newHashSet("", "text", "password", "number");
 
     /**
      * Retrieves the text value of this {@link TextField text field}. If no text
@@ -172,19 +166,6 @@ public class TextField extends PageObject implements HasText {
             }
 
         });
-    }
-
-    @Override
-    protected boolean isCorrectClassForWebElement(WebElement webElement) {
-
-        String tagName = webElement.getTagName();
-        String type = StringUtils.defaultString(webElement.getAttribute("type")).toLowerCase();
-
-        boolean isCorrectTag = INPUT_TAG.equalsIgnoreCase(tagName);
-        boolean isCorrectType = VALID_TYPES.contains(type);
-
-        return isCorrectTag && isCorrectType;
-
     }
 
     /**

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ButtonTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ButtonTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import info.novatec.testit.webtester.AbstractPageObjectTest;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class ButtonTest extends AbstractPageObjectTest {
@@ -91,37 +92,37 @@ public class ButtonTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag() {
         stubWebElementTag("button");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_buttonType() {
         stubWebElementTagAndType("input", "button");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_resetType() {
         stubWebElementTagAndType("input", "reset");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_submitType() {
         stubWebElementTagAndType("input", "submit");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_nonInputTag() {
         stubWebElementTagAndType("other", null);
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_inputTag_nonTextFieldType() {
         stubWebElementTagAndType("input", "other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/CheckboxTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/CheckboxTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import info.novatec.testit.webtester.AbstractPageObjectTest;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.SelectionChangedEvent;
 
 
@@ -161,19 +162,19 @@ public class CheckboxTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_textType() {
         stubWebElementTagAndType("input", "checkbox");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_nonInputTag() {
         stubWebElementTagAndType("other", null);
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_inputTag_nonTextFieldType() {
         stubWebElementTagAndType("input", "other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
@@ -188,10 +189,6 @@ public class CheckboxTest extends AbstractPageObjectTest {
 
     private void stubWebElementBeforeAndAfterSelectionState(boolean before, boolean after) {
         when(webElement.isSelected()).thenReturn(before, after);
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/DivTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/DivTest.java
@@ -1,12 +1,10 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class DivTest extends AbstractPageObjectTest {
@@ -17,19 +15,13 @@ public class DivTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_divTag() {
         stubWebElementTag("div");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/FormTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/FormTest.java
@@ -1,12 +1,10 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class FormTest extends AbstractPageObjectTest {
@@ -17,19 +15,13 @@ public class FormTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_formTag() {
         stubWebElementTag("form");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/HeadlineTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/HeadlineTest.java
@@ -1,12 +1,10 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class HeadlineTest extends AbstractPageObjectTest {
@@ -19,49 +17,43 @@ public class HeadlineTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_h1Tag() {
         stubWebElementTag("h1");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_h2Tag() {
         stubWebElementTag("h2");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_h3Tag() {
         stubWebElementTag("h3");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_h4Tag() {
         stubWebElementTag("h4");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_h5Tag() {
         stubWebElementTag("h5");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_h6Tag() {
         stubWebElementTag("h6");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/IFrameTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/IFrameTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class IFrameTest extends AbstractPageObjectTest {
@@ -37,19 +38,13 @@ public class IFrameTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_iframeTag() {
         stubWebElementTag("iframe");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ImageTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ImageTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import info.novatec.testit.webtester.AbstractPageObjectTest;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class ImageTest extends AbstractPageObjectTest {
@@ -97,23 +98,19 @@ public class ImageTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_imageTag() {
         stubWebElementTag("img");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
 
     private void stubImageSource(String src) {
         doReturn(src).when(webElement).getAttribute("src");
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/LinkTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/LinkTest.java
@@ -1,7 +1,5 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
@@ -10,6 +8,7 @@ import org.mockito.InjectMocks;
 import info.novatec.testit.webtester.AbstractPageObjectTest;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class LinkTest extends AbstractPageObjectTest {
@@ -42,19 +41,13 @@ public class LinkTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_aTag() {
         stubWebElementTag("a");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ListItemTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ListItemTest.java
@@ -1,12 +1,10 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class ListItemTest extends AbstractPageObjectTest {
@@ -19,19 +17,13 @@ public class ListItemTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_listItemTag() {
         stubWebElementTag("li");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ListTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/ListTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class ListTest extends AbstractPageObjectTest {
@@ -75,19 +76,19 @@ public class ListTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_orderedListTag() {
         stubWebElementTag("ol");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_unorderedListTag() {
         stubWebElementTag("ul");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
@@ -95,10 +96,6 @@ public class ListTest extends AbstractPageObjectTest {
     private void addBothItems() {
         listItems.add(listItem1);
         listItems.add(listItem2);
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/NumberFieldTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/NumberFieldTest.java
@@ -12,6 +12,7 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.TextSetEvent;
 
 
@@ -71,29 +72,25 @@ public class NumberFieldTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_numberType() {
         stubWebElementTagAndType("input", "number");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_nonInputTag() {
         stubWebElementTagAndType("other", null);
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_inputTag_nonNumberFieldType() {
         stubWebElementTagAndType("input", "other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
 
     private void stubNumberField(String value) {
         doReturn(value).when(webElement).getAttribute("value");
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/PasswordFieldTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/PasswordFieldTest.java
@@ -1,12 +1,10 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class PasswordFieldTest extends AbstractPageObjectTest {
@@ -19,25 +17,19 @@ public class PasswordFieldTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_passwordType() {
         stubWebElementTagAndType("input", "password");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_nonInputTag() {
         stubWebElementTagAndType("other", null);
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_inputTag_nonPasswordFieldType() {
         stubWebElementTagAndType("input", "other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/RadioButtonTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/RadioButtonTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import info.novatec.testit.webtester.AbstractPageObjectTest;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class RadioButtonTest extends AbstractPageObjectTest {
@@ -56,25 +57,19 @@ public class RadioButtonTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_textType() {
         stubWebElementTagAndType("input", "radio");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_nonInputTag() {
         stubWebElementTagAndType("other", null);
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_inputTag_nonTextFieldType() {
         stubWebElementTagAndType("input", "other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/SelectTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/SelectTest.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.SelectedByIndexEvent;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.SelectedByTextEvent;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.SelectedByValueEvent;
@@ -580,13 +581,13 @@ public class SelectTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_selectTag() {
         stubWebElementTag("select");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
@@ -622,10 +623,6 @@ public class SelectTest extends AbstractPageObjectTest {
 
     private void selectHasOptions(WebElement... options) {
         doReturn(Arrays.asList(options)).when(select).getOptions();
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/SpanTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/SpanTest.java
@@ -1,12 +1,10 @@
 package info.novatec.testit.webtester.pageobjects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class SpanTest extends AbstractPageObjectTest {
@@ -17,19 +15,13 @@ public class SpanTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_spanTag() {
         stubWebElementTag("span");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TableFieldTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TableFieldTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class TableFieldTest extends AbstractPageObjectTest {
@@ -34,25 +35,19 @@ public class TableFieldTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_thTag() {
         stubWebElementTag("th");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_tdTag() {
         stubWebElementTag("td");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TableRowTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TableRowTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class TableRowTest extends AbstractPageObjectTest {
@@ -82,13 +83,13 @@ public class TableRowTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_rowTag() {
         stubWebElementTag("tr");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
@@ -96,10 +97,6 @@ public class TableRowTest extends AbstractPageObjectTest {
     private void addBothFields() {
         tableFields.add(field1);
         tableFields.add(field2);
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TableTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TableTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class TableTest extends AbstractPageObjectTest {
@@ -81,13 +82,13 @@ public class TableTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_tableTag() {
         stubWebElementTag("table");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_otherTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
@@ -95,10 +96,6 @@ public class TableTest extends AbstractPageObjectTest {
     private void addBothRows() {
         tableRows.add(row1);
         tableRows.add(row2);
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TextAreaTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TextAreaTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import info.novatec.testit.webtester.AbstractPageObjectTest;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 
 
 public class TextAreaTest extends AbstractPageObjectTest {
@@ -52,19 +53,13 @@ public class TextAreaTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_textAreaTag() {
         stubWebElementTag("textarea");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_nonTextAreTag() {
         stubWebElementTag("other");
-        assertThatCorrectnessOfClassIs(false);
-    }
-
-    /* utilities */
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
+        cut.validate(webElement);
     }
 
 }

--- a/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TextFieldTest.java
+++ b/webtester-core/src/test/java/info/novatec/testit/webtester/pageobjects/TextFieldTest.java
@@ -22,6 +22,7 @@ import org.openqa.selenium.Keys;
 import info.novatec.testit.webtester.AbstractPageObjectTest;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsDisabledException;
 import info.novatec.testit.webtester.api.exceptions.PageObjectIsInvisibleException;
+import info.novatec.testit.webtester.api.exceptions.WrongElementClassException;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.TextAppendedEvent;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.TextClearedEvent;
 import info.novatec.testit.webtester.eventsystem.events.pageobject.TextSetEvent;
@@ -219,41 +220,49 @@ public class TextFieldTest extends AbstractPageObjectTest {
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag() {
         stubWebElementTagAndType("input", null);
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_emptyType() {
         stubWebElementTagAndType("input", "");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
     public void testCorrectnessOfClassForWebElement_inputTag_textType() {
         stubWebElementTagAndType("input", "text");
-        assertThatCorrectnessOfClassIs(true);
+        cut.validate(webElement);
     }
 
     @Test
+    public void testCorrectnessOfClassForWebElement_inputTag_passwordType() {
+        stubWebElementTagAndType("input", "password");
+        cut.validate(webElement);
+    }
+
+    @Test
+    public void testCorrectnessOfClassForWebElement_inputTag_numberType() {
+        stubWebElementTagAndType("input", "number");
+        cut.validate(webElement);
+    }
+
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_nonInputTag() {
         stubWebElementTagAndType("other", null);
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
-    @Test
+    @Test(expected = WrongElementClassException.class)
     public void testCorrectnessOfClassForWebElement_inputTag_nonTextFieldType() {
         stubWebElementTagAndType("input", "other");
-        assertThatCorrectnessOfClassIs(false);
+        cut.validate(webElement);
     }
 
     /* utilities */
 
     private void stubWebElementBeforeAndAfterTexts(String before, String after) {
         when(webElement.getAttribute("value")).thenReturn(before, after);
-    }
-
-    private void assertThatCorrectnessOfClassIs(boolean expected) {
-        assertThat(cut.isCorrectClassForWebElement(webElement), is(expected));
     }
 
 }


### PR DESCRIPTION
With this we can provide an elegant and concise way of validating page object classes.

It replaces the current per implementation validation (by overriding the isValidClassFor... method in PageObject) with an annotation based approach. The old method was deprecated and will be removed in v1.3.0.

**Examples:**
* ```@Mapping(tag="div")``` Will be evaluated as 'valid' in case the web element has the tag 'div'.
* ```@Mapping(tag="select", attribute="multiple")``` Will be evaluated as 'valid' in case the web element has the tag 'select' and the 'multiple' attribute is present.
* ```@Mapping(tag="select", attribute="!multiple")``` Will be evaluated as 'valid' in case the web element has the tag 'select' and the 'multiple' attribute is not present.
* ```@Mapping(tag="input", attribute="type", values={"text", "password"})``` Will be evaluated as 'valid' in case the web element has the tag 'input' and the 'type' attribute has either the 'text' oder 'password' value.
* ```@Mapping(validator=FooValidator.class)``` Will create a new instance of the given validator class and use it to evaluate the web element.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester-core/31)
<!-- Reviewable:end -->
