### PR TITLE
Replaced property "browser.autoClose" with the more fitting "cleanup.closeLeftoverBrowsers"

### DIFF
--- a/documentation/chapters/configuration.md
+++ b/documentation/chapters/configuration.md
@@ -83,10 +83,11 @@ The values are the same as the fallback values of the `BaseConfiguration` implem
 # URL of the default entry point for the application under test.
 # TYPE: String [Resource URL]
 # browser.defaultEntryPoint =
- 
-# Weather or not open browsers should be closed automatically when the JVM is shut down.
+
+# Whether or not leftover browsers should be closed automatically when the JVM is shut down.
+# Setting this property will have no impact on the browser's close method or other mechanisms for closing the browser either automatically or manually (i.e. JUnitRunner extension)
 # TYPE: boolean [true, false]
-browser.autoClose = false
+cleanup.closeLeftoverBrowsers = false
  
 # Format pattern for timestamps to be used when printing timestamps.
 # TYPE: String [Java SimpleDateFormat style as described here: https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html]

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/api/config/Configuration.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/api/config/Configuration.java
@@ -247,7 +247,7 @@ public interface Configuration {
      * @return true if browser should be closed automatically, otherwise false
      * @since 0.9.7
      */
-    boolean browserShouldCloseAutomatically();
+    boolean cleanupLeftoverBrowsers();
 
     /**
      * Sets whether or not created browsers should tried to be closed when the
@@ -260,7 +260,7 @@ public interface Configuration {
      * @return the same configuration for fluent API
      * @since 0.9.7
      */
-    Configuration setBrowserShouldCloseAutomatically(boolean browserShouldCloseAutomatically);
+    Configuration setCleanupLeftoverBrowsers(boolean browserShouldCloseAutomatically);
 
     /**
      * Returns whether or not the {@link PageObject page object's}

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/browser/WebDriverBrowserBuilder.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/browser/WebDriverBrowserBuilder.java
@@ -80,7 +80,7 @@ public class WebDriverBrowserBuilder implements BrowserBuilder {
     }
 
     private void addShutdownHook(final WebDriverBrowser browser) {
-        if (browser.getConfiguration().browserShouldCloseAutomatically()) {
+        if (browser.getConfiguration().cleanupLeftoverBrowsers()) {
             Runtime.getRuntime().addShutdownHook(new Thread() {
 
                 @Override

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/config/BaseConfiguration.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/config/BaseConfiguration.java
@@ -155,13 +155,13 @@ public class BaseConfiguration implements Configuration {
     }
 
     @Override
-    public boolean browserShouldCloseAutomatically() {
-        return getBooleanProperty(key(NamedProperties.BROWSER_SHOULD_AUTOCLOSE), Boolean.FALSE);
+    public boolean cleanupLeftoverBrowsers() {
+        return getBooleanProperty(key(NamedProperties.CLEANUP_LEFTOVER_BROWSERS), Boolean.FALSE);
     }
 
     @Override
-    public BaseConfiguration setBrowserShouldCloseAutomatically(boolean browserShouldCloseAutomatically) {
-        return setProperty(key(NamedProperties.BROWSER_SHOULD_AUTOCLOSE), browserShouldCloseAutomatically);
+    public BaseConfiguration setCleanupLeftoverBrowsers(boolean enabled) {
+        return setProperty(key(NamedProperties.CLEANUP_LEFTOVER_BROWSERS), enabled);
     }
 
     @Override

--- a/webtester-core/src/main/java/info/novatec/testit/webtester/internal/NamedProperties.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/internal/NamedProperties.java
@@ -16,10 +16,12 @@ public enum NamedProperties {
     @TypeDefinition(Constants.RESOURCE_URL)
     BROWSER_DEFAULT_ENTRY_POINT("browser.defaultEntryPoint"),
 
-    @Documentation("Whether or not open browsers should be closed automatically when the JVM is shut down.")
+    @Documentation("Whether or not leftover browsers should be closed automatically when the JVM is shut down."
+        + "\nSetting this property will have no impact on the browser's close method or other mechanisms for closing"
+        + " the browser either automatically or manually (i.e. JUnitRunner extension)")
     @TypeDefinition(Constants.BOOLEAN)
     @DefaultValue("false")
-    BROWSER_SHOULD_AUTOCLOSE("browser.autoClose"),
+    CLEANUP_LEFTOVER_BROWSERS("cleanup.closeLeftoverBrowsers"),
 
     @Documentation("Format pattern for timestamps to be used when printing timestamps.")
     @TypeDefinition(Constants.SIMPLE_DATE_FORMAT)

--- a/webtester-core/src/main/resources/testit-webtester-default.properties
+++ b/webtester-core/src/main/resources/testit-webtester-default.properties
@@ -2,9 +2,10 @@
 # TYPE: String [Resource URL]
 # browser.defaultEntryPoint = 
 
-# Whether or not open browsers should be closed automatically when the JVM is shut down.
+# Whether or not leftover browsers should be closed automatically when the JVM is shut down.
+# Setting this property will have no impact on the browser's close method or other mechanisms for closing the browser either automatically or manually (i.e. JUnitRunner extension)
 # TYPE: boolean [true, false]
-browser.autoClose = false
+cleanup.closeLeftoverBrowsers = false
 
 # Format pattern for timestamps to be used when printing timestamps.
 # TYPE: String [Java SimpleDateFormat style as described here: https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html]

--- a/webtester-core/src/test/resources/testit-webtester.properties
+++ b/webtester-core/src/test/resources/testit-webtester.properties
@@ -1,4 +1,4 @@
 folders.screenshot             = target/screenshots
 folders.sourcecode             = target/sourcecode
 folders.log                    = target/logs
-browser.autoClose              = true
+cleanup.closeLeftoverBrowsers  = true


### PR DESCRIPTION
Since the property only triggered the creation of a shutdown hook in order to cleanup browsers that were not closed properly the old name was deemed confusing.
The new name and more extensive documentation should make it clear what that property actually does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester-core/34)
<!-- Reviewable:end -->
