### PR TITLE
Added a method to change the value of any attribute of any page object using JavaScript

### DIFF
--- a/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/PageObject.java
+++ b/webtester-core/src/main/java/info/novatec/testit/webtester/pageobjects/PageObject.java
@@ -260,6 +260,25 @@ public class PageObject implements Invalidateable {
     }
 
     /**
+     * Sets the value of an attribute of this {@link PageObject} using JavaScript.
+     * <p>
+     * <b>Example:</b>
+     * <pre>
+     * // will change the value of a text field to 'foo'
+     * textField.setAttribute("value", "foo");
+     * </pre>
+     *
+     * @param attributeName the name of the attribute to set
+     * @param value the value to set the attribute to
+     * @since 1.2.0
+     */
+    public void setAttribute(String attributeName, String value) {
+        String escapedValue = StringUtils.replace(value, "\"", "\\\"");
+        String script = "arguments[0]." + attributeName + " = \"" + escapedValue + "\"";
+        getBrowser().executeJavaScript(script, this, value);
+    }
+
+    /**
      * @param attributeName the name of the attribute for which the value should
      * be returned
      * @return the value of the given attribute, or null if the attribute is not

--- a/webtester-core/src/test/java/integration/pageobjects/PageObjectIntegrationTest.java
+++ b/webtester-core/src/test/java/integration/pageobjects/PageObjectIntegrationTest.java
@@ -136,6 +136,22 @@ public class PageObjectIntegrationTest extends AbstractWebTesterIntegrationTest 
         assertThat(element.getAttribute(UNKNOWN), is(nullValue()));
     }
 
+    /* setting attribute */
+
+    @Test
+    public void setAttribute() {
+        TextField textField = getBrowser().create(TestPage.class).forSetAttribute;
+        textField.setAttribute("value", "hello world!");
+        assertThat(textField.getText(), is(equalTo("hello world!")));
+    }
+
+    @Test
+    public void setAttributeWithCharactersThatNeedEscaping() {
+        TextField textField = getBrowser().create(TestPage.class).forSetAttribute;
+        textField.setAttribute("value", "hello \"world!\"");
+        assertThat(textField.getText(), is(equalTo("hello \"world!\"")));
+    }
+
     /* testGetCssProperty */
 
     @Test
@@ -171,6 +187,13 @@ public class PageObjectIntegrationTest extends AbstractWebTesterIntegrationTest 
     public PageObject getPageObjectForID(String id) {
         PageObjectModel metaData = PageObjectModel.forPageFragment(getBrowser(), Identifications.id(id), null);
         return new DefaultPageObjectFactory().create(PageObject.class, metaData);
+    }
+
+    public static class TestPage extends PageObject {
+
+        @IdentifyUsing("forSetAttribute")
+        TextField forSetAttribute;
+
     }
 
     public static class InvalidationPageObject extends PageObject {

--- a/webtester-core/src/test/resources/html/pageobject/base/index.html
+++ b/webtester-core/src/test/resources/html/pageobject/base/index.html
@@ -95,6 +95,12 @@
 
 	<span id="spanIsNotVisible" style="display: none">invisible element</span>
 
+	<!-- set attribute -->
+
+	<br>
+	<br>
+
+	<input id="forSetAttribute" type="text" value=""/>
 
 </body>
 </html>


### PR DESCRIPTION
Depending on the used UI Framework there might be problems with setting a TextField's text with 'conventional' methods (i.e. setText()).

One Example of this was a text field which invoked a JavaScrip whenever it's value had changed. That script then set the field's value to 0 in case the field was empty. The only way to set this field's value from a test was to use JavaScript as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-webtester/webtester-core/37)
<!-- Reviewable:end -->
